### PR TITLE
Fixed crash/assert in im_gui if scroll area gets out of the visible area

### DIFF
--- a/src/imgui_console.cpp
+++ b/src/imgui_console.cpp
@@ -257,10 +257,9 @@ void ImGuiConsole::LogWindow()
         if ((m_ScrollToBottom && (ImGui::GetScrollY() >= ImGui::GetScrollMaxY() || m_AutoScroll)))
             ImGui::SetScrollHereY(1.0f);
         m_ScrollToBottom = false;
-
-        // Loop through command string vector.
-        ImGui::EndChild();
     }
+    // Loop through command string vector.
+    ImGui::EndChild();
 }
 
 void ImGuiConsole::InputBar()


### PR DESCRIPTION
**Problem:**
When using imgui_console with more recent im_gui versions, we got asserts due to BeginChild/EndChild inconsistencies: If ImGui::BeginChild("ScrollRegion##"..) returned false, ImGui.EndChild wasn't called (because it was inside the if-block). This caused an assert in a later End() call:
IM_ASSERT_USER_ERROR(g.WithinEndChild, "Must call EndChild() and not End()!");

**Fix:**
Moving the EndChild() call outside the if-scope (to always call it) fixed the problem. Note that (at least for more recent imgui versions) always push the child window - no matter whether the function returned true or false.